### PR TITLE
feat(colours): add support for RGB and Hex triplet conversion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   min-rust-version:
     type: string
-    default: "1.33"
+    default: "1.61"
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   min-rust-version:
     type: string
-    default: "1.61"
+    default: "1.65"
   fingerprint:
     type: string
     default: SHA256:OkxsH8Z6Iim6WDJBaII9eTT9aaO1f3eDc6IpsgYYPVg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add support for RGB and Hex triplet conversion(pr [#34])
+
 ### Changed
 
 - chore(circleci)-update toolkit orb to version 1.5.0 and add update_changelog parameter(pr [#32])
@@ -82,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#31]: https://github.com/jerus-org/named-colour/pull/31
 [#32]: https://github.com/jerus-org/named-colour/pull/32
 [#33]: https://github.com/jerus-org/named-colour/pull/33
+[#34]: https://github.com/jerus-org/named-colour/pull/34
 [Unreleased]: https://github.com/jerus-org/named-colour/compare/v0.1.6...HEAD
 [0.1.6]: https://github.com/jerus-org/named-colour/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/jerus-org/named-colour/compare/v0.1.4...v0.1.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,366 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "bytemuck"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "named-colour"
 version = "0.1.6"
+dependencies = [
+ "rgb",
+ "rstest",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+ "serde",
+]
+
+[[package]]
+name = "rstest"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ documentation = "https://docs.rs/named-colour"
 categories = ["web-programming", "visualization"]
 keywords = ["colours", "constants", "reference"]
 include = ["**/*.rs", "Cargo.toml"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.61"
 
 [features]
 default = ["basic"]
@@ -23,6 +24,8 @@ extended = []
 
 [dependencies]
 rgb = { version = "0.8.50", features = ["serde"] }
+
+[dev-dependencies]
 rstest = "0.22.0"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming", "visualization"]
 keywords = ["colours", "constants", "reference"]
 include = ["**/*.rs", "Cargo.toml"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.65"
 
 [features]
 default = ["basic"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ extended = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rgb = { version = "0.8.50", features = ["serde"] }
+rstest = "0.22.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -1,19 +1,18 @@
 use std::fmt;
 
+use rgb::Rgb;
+
+use crate::Prefix;
+
 /// 16 basic colours with 18 names!
+#[allow(missing_docs)]
 #[derive(Debug)]
 pub enum Basic {
-    #[allow(missing_docs)]
     Black,
-    #[allow(missing_docs)]
     White,
-    #[allow(missing_docs)]
     Red,
-    #[allow(missing_docs)]
     Lime,
-    #[allow(missing_docs)]
     Blue,
-    #[allow(missing_docs)]
     Yellow,
     /// Alternate name for Aqua
     Cyan,
@@ -23,21 +22,13 @@ pub enum Basic {
     Magenta,
     /// Alternate name for Magenta
     Fuchsia,
-    #[allow(missing_docs)]
     Silver,
-    #[allow(missing_docs)]
     Gray,
-    #[allow(missing_docs)]
     Maroon,
-    #[allow(missing_docs)]
     Olive,
-    #[allow(missing_docs)]
     Green,
-    #[allow(missing_docs)]
     Purple,
-    #[allow(missing_docs)]
     Teal,
-    #[allow(missing_docs)]
     Navy,
 }
 
@@ -79,36 +70,173 @@ impl Basic {
     /// # }
     ///```
 
+    #[deprecated(
+        since = "0.2.0",
+        note = "Use `to_rgb` for Rgb struct and `to_string()` to deisplay as decimal Rgb triplet instead"
+    )]
     pub fn as_rgb(&self) -> String {
         match self {
-            Basic::Black => crate::to_rgb("#000000"),
-            Basic::White => crate::to_rgb("#FFFFFF"),
-            Basic::Red => crate::to_rgb("#FF0000"),
-            Basic::Lime => crate::to_rgb("#00FF00"),
-            Basic::Blue => crate::to_rgb("#0000FF"),
-            Basic::Yellow => crate::to_rgb("#FFFF00"),
-            Basic::Cyan => crate::to_rgb("#00FFFF"),
             Basic::Aqua => crate::to_rgb("#00FFFF"),
-            Basic::Magenta => crate::to_rgb("#FF00FF"),
+            Basic::Black => crate::to_rgb("#000000"),
+            Basic::Blue => crate::to_rgb("#0000FF"),
+            Basic::Cyan => crate::to_rgb("#00FFFF"),
             Basic::Fuchsia => crate::to_rgb("#FF00FF"),
-            Basic::Silver => crate::to_rgb("#C0C0C0"),
             Basic::Gray => crate::to_rgb("#808080"),
-            Basic::Maroon => crate::to_rgb("#800000"),
-            Basic::Olive => crate::to_rgb("#808000"),
             Basic::Green => crate::to_rgb("#008000"),
-            Basic::Purple => crate::to_rgb("#800080"),
-            Basic::Teal => crate::to_rgb("#008080"),
+            Basic::Magenta => crate::to_rgb("#FF00FF"),
+            Basic::Lime => crate::to_rgb("#00FF00"),
+            Basic::Maroon => crate::to_rgb("#800000"),
             Basic::Navy => crate::to_rgb("#000080"),
+            Basic::Olive => crate::to_rgb("#808000"),
+            Basic::Purple => crate::to_rgb("#800080"),
+            Basic::Red => crate::to_rgb("#FF0000"),
+            Basic::Silver => crate::to_rgb("#C0C0C0"),
+            Basic::Teal => crate::to_rgb("#008080"),
+            Basic::White => crate::to_rgb("#FFFFFF"),
+            Basic::Yellow => crate::to_rgb("#FFFF00"),
         }
+    }
+
+    /// Display the colour name as an RGB Tuple
+    ///
+    /// ## Example
+    ///
+    ///```
+    /// # use named_colour::Basic;
+    /// # fn main() {
+    ///    let rgb_colour = Basic::Black.to_rgb();
+    ///    let string = rgb_colour.to_string();
+    ///    assert_eq!("rgb(0,0,0)", string);
+    ///
+    ///  # }
+    ///```
+
+    pub fn to_rgb(&self) -> Rgb<u8> {
+        let colour = match self {
+            Basic::Black => "#000000",
+            Basic::White => "#FFFFFF",
+            Basic::Red => "#FF0000",
+            Basic::Lime => "#00FF00",
+            Basic::Blue => "#0000FF",
+            Basic::Yellow => "#FFFF00",
+            Basic::Cyan => "#00FFFF",
+            Basic::Aqua => "#00FFFF",
+            Basic::Magenta => "#FF00FF",
+            Basic::Fuchsia => "#FF00FF",
+            Basic::Silver => "#C0C0C0",
+            Basic::Gray => "#808080",
+            Basic::Maroon => "#800000",
+            Basic::Olive => "#808000",
+            Basic::Green => "#008000",
+            Basic::Purple => "#800080",
+            Basic::Teal => "#008080",
+            Basic::Navy => "#000080",
+        };
+
+        let r: u8 = u8::from_str_radix(&colour[1..3], 16).unwrap();
+        let g: u8 = u8::from_str_radix(&colour[3..5], 16).unwrap();
+        let b: u8 = u8::from_str_radix(&colour[5..7], 16).unwrap();
+
+        Rgb::new(r, g, b)
+    }
+
+    /// Display the colour name as an RGB Tuple
+    ///
+    /// ## Example
+    ///
+    ///```
+    /// # use named_colour::Basic;
+    ///     let colour = Basic::Black;
+    ///
+    ///     assert_eq!("#000000)", colour.to_hex_triplet(Prefix::Hash));
+    ///
+    ///```
+
+    pub fn to_hex_triplet(&self, prefix: Prefix) -> String {
+        let rgb = self.to_rgb();
+
+        let prefix = match prefix {
+            Prefix::Hash => "#",
+            Prefix::None => "",
+        };
+
+        format!("{}{:02X}{:02X}{:02X}", prefix, rgb.r, rgb.g, rgb.b)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
     fn display_as_rgb() {
         assert_eq!("(0,255,255)", Basic::Aqua.as_rgb())
+    }
+
+    #[rstest]
+    #[case(Basic::Aqua, "rgb(0,255,255)")]
+    #[case(Basic::Black, "rgb(0,0,0)")]
+    #[case(Basic::Blue, "rgb(0,0,255)")]
+    #[case(Basic::Cyan, "rgb(0,255,255)")]
+    #[case(Basic::Fuchsia, "rgb(255,0,255)")]
+    #[case(Basic::Gray, "rgb(128,128,128)")]
+    #[case(Basic::Green, "rgb(0,128,0)")]
+    #[case(Basic::Magenta, "rgb(255,0,255)")]
+    #[case(Basic::Lime, "rgb(0,255,0)")]
+    #[case(Basic::Maroon, "rgb(128,0,0)")]
+    #[case(Basic::Navy, "rgb(0,0,128)")]
+    #[case(Basic::Olive, "rgb(128,128,0)")]
+    #[case(Basic::Purple, "rgb(128,0,128)")]
+    #[case(Basic::Red, "rgb(255,0,0)")]
+    #[case(Basic::Silver, "rgb(192,192,192)")]
+    #[case(Basic::Teal, "rgb(0,128,128)")]
+    #[case(Basic::White, "rgb(255,255,255)")]
+    #[case(Basic::Yellow, "rgb(255,255,0)")]
+    fn test_rgb_string(#[case] colour: Basic, #[case] expected: String) {
+        let rgb_colour = colour.to_rgb();
+        let string = rgb_colour.to_string();
+
+        assert_eq!(expected, string);
+
+        // assert!(Basic::Black.to_hex_triplet(Prefix::None) == "000000");
+        // assert!(Basic::Black.to_hex_triplet(Prefix::Hash) == "#000000");
+    }
+
+    #[rstest]
+    #[case(Basic::Aqua, "00FFFF")]
+    #[case(Basic::Black, "000000")]
+    #[case(Basic::Blue, "0000FF")]
+    #[case(Basic::Cyan, "00FFFF")]
+    #[case(Basic::Fuchsia, "FF00FF")]
+    #[case(Basic::Gray, "808080")]
+    #[case(Basic::Green, "008000")]
+    #[case(Basic::Magenta, "FF00FF")]
+    #[case(Basic::Lime, "00FF00")]
+    #[case(Basic::Maroon, "800000")]
+    #[case(Basic::Navy, "000080")]
+    #[case(Basic::Olive, "808000")]
+    #[case(Basic::Purple, "800080")]
+    #[case(Basic::Red, "FF0000")]
+    #[case(Basic::Silver, "C0C0C0")]
+    #[case(Basic::Teal, "008080")]
+    #[case(Basic::White, "FFFFFF")]
+    #[case(Basic::Yellow, "FFFF00")]
+    fn test_hex_triplet_string(
+        #[case] colour: Basic,
+        #[values(Prefix::None, Prefix::Hash)] prefix: Prefix,
+        #[case] expected: String,
+    ) {
+        let prefix_string = match prefix {
+            Prefix::None => "".to_string(),
+            Prefix::Hash => "#".to_string(),
+        };
+
+        let expected = format!("{}{}", prefix_string, expected);
+
+        let hex_colour = colour.to_hex_triplet(prefix);
+
+        assert_eq!(expected, hex_colour);
     }
 }

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -72,7 +72,8 @@ impl Basic {
 
     #[deprecated(
         since = "0.2.0",
-        note = "Use `to_rgb` for Rgb struct an then `to_string()` to display as decimal Rgb triplet instead"
+        note = r#"Use `to_rgb` for Rgb struct an then `to_string()` to display as decimal Rgb triplet instead
+        Will be removed in 0.3.0"#
     )]
     pub fn as_rgb(&self) -> String {
         match self {

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -72,7 +72,7 @@ impl Basic {
 
     #[deprecated(
         since = "0.2.0",
-        note = "Use `to_rgb` for Rgb struct and `to_string()` to deisplay as decimal Rgb triplet instead"
+        note = "Use `to_rgb` for Rgb struct an then `to_string()` to display as decimal Rgb triplet instead"
     )]
     pub fn as_rgb(&self) -> String {
         match self {
@@ -146,6 +146,7 @@ impl Basic {
     ///
     ///```
     /// # use named_colour::Basic;
+    /// # use named_colour::Prefix;
     ///     let colour = Basic::Black;
     ///
     ///     assert_eq!("#000000)", colour.to_hex_triplet(Prefix::Hash));
@@ -171,6 +172,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(deprecated)]
     fn display_as_rgb() {
         assert_eq!("(0,255,255)", Basic::Aqua.as_rgb())
     }

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -149,7 +149,7 @@ impl Basic {
     /// # use named_colour::Prefix;
     ///     let colour = Basic::Black;
     ///
-    ///     assert_eq!("#000000)", colour.to_hex_triplet(Prefix::Hash));
+    ///     assert_eq!("#000000", colour.to_hex_triplet(Prefix::Hash));
     ///
     ///```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,12 @@ pub(crate) fn to_rgb(hex: &str) -> String {
     }
 }
 
+#[allow(missing_docs)]
+pub enum Prefix {
+    None,
+    Hash,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,8 @@ mod basic;
 pub mod ext;
 mod rgb;
 
+pub use crate::rgb::ColourRgb;
 pub use basic::Basic;
-pub use rgb::ColourRgb;
 
 pub(crate) fn to_rgb(hex: &str) -> String {
     let mut no_error = true;


### PR DESCRIPTION
- add `to_rgb` method to convert basic colours to RGB tuples
- add `to_hex_triplet` method to display colours as hex triplets
- deprecate `as_rgb` method in favour of `to_rgb` method
- include new tests for RGB and Hex triplet conversion
- reorganize imports and remove redundant attributes