### PR TITLE
chore: update release.toml to reference PRLOG.md instead of CHANGELOG.md

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - chore-rename CHANGELOG.md to PRLOG.md(pr [#118])
+- chore-update release.toml to reference PRLOG.md instead of CHANGELOG.md(pr [#119])
 
 ## [0.3.23] - 2025-08-21
 
@@ -396,6 +397,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#117]: https://github.com/jerus-org/named-colour/pull/117
 [#116]: https://github.com/jerus-org/named-colour/pull/116
 [#118]: https://github.com/jerus-org/named-colour/pull/118
+[#119]: https://github.com/jerus-org/named-colour/pull/119
 [Unreleased]: https://github.com/jerus-org/named-colour/compare/v0.3.23...HEAD
 [0.3.23]: https://github.com/jerus-org/named-colour/compare/v0.3.22...v0.3.23
 [0.3.22]: https://github.com/jerus-org/named-colour/compare/v0.3.21...v0.3.22

--- a/release.toml
+++ b/release.toml
@@ -3,9 +3,9 @@ pre-release-replacements = [
     { file = "README.md", search = """named-colour = \\{ version = "\\d+.\\d+.\\d+",""", replace = """named-colour = { version = "{{version}}",""", exactly = 2 },
     { file = "src/lib.rs", search = """named-colour = "\\d+.\\d+.\\d+"""", replace = "{{crate_name}} = \"{{version}}\"", exactly = 1 },
     { file = "src/lib.rs", search = """named-colour = \\{ version = "\\d+.\\d+.\\d+",""", replace = """{{crate_name}} = { version = "{{version}}",""", exactly = 2 },
-    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+    { file = "PRLOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
+    { file = "PRLOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
+    { file = "PRLOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
 ]
 pre-release-commit-message = "chore: Release"
 tag-message = "{{tag_name}}"


### PR DESCRIPTION
This PR updates the `release.toml` configuration file to reference `PRLOG.md` instead of `CHANGELOG.md`.

## Changes
- Updated all file references from `CHANGELOG.md` to `PRLOG.md` in `release.toml`
- No functional changes to the release process, only file name consistency

## Context
This change aligns with the recent standardization effort to use `PRLOG.md` (Pull Request Log) as the consistent naming convention for changelog files across all repositories. The release automation tooling now properly references the renamed changelog file.

## Files Modified
- `release.toml` - Updated file references in release configuration