### PR TITLE
feat: add release-hook.sh script for automated changelog generation

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add release-hook.sh script for automated changelog generation(pr [#120])
+
 ### Changed
 
 - chore-rename CHANGELOG.md to PRLOG.md(pr [#118])
@@ -398,6 +402,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#116]: https://github.com/jerus-org/named-colour/pull/116
 [#118]: https://github.com/jerus-org/named-colour/pull/118
 [#119]: https://github.com/jerus-org/named-colour/pull/119
+[#120]: https://github.com/jerus-org/named-colour/pull/120
 [Unreleased]: https://github.com/jerus-org/named-colour/compare/v0.3.23...HEAD
 [0.3.23]: https://github.com/jerus-org/named-colour/compare/v0.3.22...v0.3.23
 [0.3.22]: https://github.com/jerus-org/named-colour/compare/v0.3.21...v0.3.22

--- a/release-hook.sh
+++ b/release-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Build Changelog
+gen-changelog generate --display-summaries --next-version "$SEMVER"


### PR DESCRIPTION
This PR adds a release-hook.sh script to enable automated changelog generation during the release process.

## Changes
- Added release-hook.sh script (executable)
- Script integrates with release tooling to generate changelog entries

## Purpose
This script will be automatically executed during the release process to generate changelog entries using the gen-changelog tool and update the PRLOG.md file with version-specific information.